### PR TITLE
Faster enemy count detection

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class Enemy : Entity
 {
+    public delegate void Died(GameObject who);
+    public event Died deathEvent;
+
     private void Start()
     {
         MaxHealth = 1;
@@ -42,6 +45,7 @@ public class Enemy : Entity
 
         if (Health == 0)
         {
+            deathEvent?.Invoke(gameObject);
             // TODO make eligible for possession instead of destroying
             Destroy(gameObject);
         }

--- a/Assets/Scripts/Spawning/SpawnScript.cs
+++ b/Assets/Scripts/Spawning/SpawnScript.cs
@@ -7,10 +7,12 @@ public class SpawnScript : MonoBehaviour
     /* Loops through all children SpawnPoint objects and spawns enemies at those points.
      * Returns a list of all spawned enemies.
      */ 
-    public void SpawnEnemies()
+    public HashSet<GameObject> SpawnEnemies()
     {
+        HashSet<GameObject> spawned = new HashSet<GameObject>();
+
         // Loop through each spawn point
-        foreach(Transform child in transform)
+        foreach (Transform child in transform)
         {
             SpawnPoint spawnPoint = child.gameObject.GetComponent<SpawnPoint>();
             GameObject enemyToSpawn = spawnPoint.enemyPrefab;
@@ -19,8 +21,11 @@ public class SpawnScript : MonoBehaviour
             if (enemyToSpawn != null)
             {
                 enemyToSpawn.tag = "Enemy";
-                Instantiate(enemyToSpawn, spawnPoint.transform.position, Quaternion.identity);
+                GameObject spawnedEnemy = Instantiate(enemyToSpawn, spawnPoint.transform.position, Quaternion.identity);
+                spawned.Add(spawnedEnemy);
             }
         }
+
+        return spawned;
     }
 }


### PR DESCRIPTION
I know that it's the prototype and that optimization shouldn't be a priority, but I didn't like how there would always be a delay after killing enemies before the doors would open. It gave the impression that the game environment was not responsive to player actions, so I figured it was best to refine it.

I managed to figure it out, though. Basically, each enemy will emit a death event when its health reaches zero. The room gets a hash set of all enemies that the spawner generated, and it's then able to subscribe to each of those enemies' events. When the number of enemies hits zero, all doors open.

Honestly, either this or Jason's solution work fine; I think this is just cleaner to keep track of, and more efficient because the room doesn't sit in a loop anymore.

@klein1992  One benefit to this approach is we now have a hash set of all currently alive enemies in the room. That means when the player enters the room, we can loop through each enemy and have them follow the player. That way, enemies one room over don't try to pursue the player through walls—they only pursue the player if the room has instructed them to :)