### PR TITLE
Fix possession input buffer bug

### DIFF
--- a/Assets/Scripts/Posession.cs
+++ b/Assets/Scripts/Posession.cs
@@ -18,10 +18,15 @@ public class Posession : MonoBehaviour
     {
         // Rinky dink shit to keep the trigger method from being called twice...
         timer += Time.deltaTime;
-        if (Input.GetAxis("Posess") != 0 && timer > cooldown)
+        if (timer > cooldown)
         {
-            possessInput = true;
-            timer = 0;
+            // Reset the possess input
+            possessInput = false;
+            if (Input.GetAxis("Posess") != 0)
+            {
+                possessInput = true;
+                timer = 0;
+            }
         }
     }
 


### PR DESCRIPTION
Fix the bug with the possession input getting permanently buffered. This solution will still have the effect where the input will be buffered for 2 seconds.